### PR TITLE
Fixed grammatical error

### DIFF
--- a/src/commands/createflow.js
+++ b/src/commands/createflow.js
@@ -87,7 +87,7 @@ module.exports.run = async (message, _, gdb) => {
             "• `edit <trigger or action> <slot>`: Edit a trigger or action's slot.",
             "• `save`: Save the flow.",
             "• `cancel`: Cancel the creation without saving.",
-            "**__The commands does not require the bot prefix, just simply write it in the channel.__** Also notice that normal bot commands have been disabled in this channel."
+            "**__The commands do not require the bot prefix, just simply write it in the channel.__** Also notice that normal bot commands have been disabled in this channel."
           ].join("\n")
         },
         {


### PR DESCRIPTION
 “Do” is used when referring to more than one person or thing, the word “does” is used in sentences that refer to a single person or thing, as this sentence refers to multiple commands "do" makes more sense here.