### PR TITLE
Catch() error when making a channel

### DIFF
--- a/src/commands/setup.js
+++ b/src/commands/setup.js
@@ -19,7 +19,16 @@ module.exports.run = async (message, _, gdb) => {
     if (!overwrite) return message.channel.send("✴️ New configuration canceled.");
   }
 
-  if (!message.guild.me.hasPermission("MANAGE_CHANNELS")) return message.channel.send("❌ The bot is missing the `Manage Channels`-permission. Please fix the issue and retry.");
+  const perms = [
+    "MANAGE_CHANNELS",
+    "MANAGE_ROLES", // manage permissions
+    "VIEW_CHANNEL",
+    "SEND_MESSAGES",
+    "MANAGE_MESSAGES",
+    "EMBED_LINKS",
+    "READ_MESSAGE_HISTORY",
+    "MANAGE_WEBHOOKS"
+  ];
 
   const newChannel = await message.guild.channels.create("counting", {
     parent: message.channel.parent,
@@ -27,18 +36,11 @@ module.exports.run = async (message, _, gdb) => {
     permissionOverwrites: [
       {
         id: message.client.user.id,
-        allow: [
-          "MANAGE_CHANNELS",
-          "MANAGE_ROLES", // manage permissions
-          "VIEW_CHANNEL",
-          "SEND_MESSAGES",
-          "MANAGE_MESSAGES",
-          "EMBED_LINKS",
-          "READ_MESSAGE_HISTORY",
-          "MANAGE_WEBHOOKS"
-        ]
+        allow: perms
       }
     ]
+  }).catch(e => {
+    if(e) return message.channel.send(`❌ The bot is missing permissions to make a channel. Make sure it has the following permissions:\n\`\`\`css\n${perms.join("\n").replace(/_/g, " ")}\`\`\``);
   });
 
   gdb.setMultiple({


### PR DESCRIPTION
Discord deployed a breaking change to the Create Guild Channel endpoint.

This commit adds a `catch()` method to deal with permission issues.
Countr now tells the user which permissions are required for setup.