### PR TITLE
[Emergency Fix] Made it so users & roles can not be pinged via the webhook. 

### DIFF
--- a/src/handlers/counting.js
+++ b/src/handlers/counting.js
@@ -82,7 +82,7 @@ module.exports = async (message, gdb) => {
       countingMessage = await webhook.send(message.content, {
         username: message.author.username,
         avatarURL: message.author.displayAvatarURL({ dynamic: true }),
-        allowed_mentions: {
+        allowedMentions: {
           users: [],
           roles: [],
           parse: [],

--- a/src/handlers/counting.js
+++ b/src/handlers/counting.js
@@ -1,14 +1,14 @@
 const { getPermissionLevel, limitFlows, flow: { triggers: allTriggers, actions: allActions }, limitTriggers, limitActions } = require("../constants/index.js"), config = require("../../config.json"), countingFails = new Map(), RE2 = require("re2");
 
 module.exports = async (message, gdb) => {
-  const permissionLevel = getPermissionLevel(message.member);
+  const permissionLevel = getPermissionLevel(message.member), content = message.content;
 
-  if (message.content.startsWith("!") && permissionLevel >= 1) return;
+  if (content.startsWith("!") && permissionLevel >= 1) return;
 
   let { count, user, modules, regex, notifications, flows, users: scores, timeoutrole } = gdb.get(), regexMatches = false, flowIDs = Object.keys(flows).slice(0, limitFlows);
   if (regex.length && permissionLevel == 0)
     for (let r of regex)
-      if ((new RE2(r, "g")).test(message.content)) {
+      if ((new RE2(r, "g")).test(content)) {
         regexMatches = true;
         break;
       }
@@ -16,8 +16,8 @@ module.exports = async (message, gdb) => {
   if (
     regexMatches ||
     (!modules.includes("allow-spam") && message.author.id == user) ||
-    (!modules.includes("talking") && message.content !== (count + 1).toString()) ||
-    message.content.split(" ")[0] !== (count + 1).toString()
+    (!modules.includes("talking") && content !== (count + 1).toString()) ||
+    content.split(" ")[0] !== (count + 1).toString()
   ) {
     // set up countdata for flows
     const countData = {
@@ -79,7 +79,7 @@ module.exports = async (message, gdb) => {
     if (!webhook) webhook = await message.channel.createWebhook("Countr").catch(() => null);
 
     if (webhook) {
-      countingMessage = await webhook.send(message.content, {
+      countingMessage = await webhook.send(content, {
         username: message.author.username,
         avatarURL: message.author.displayAvatarURL({ dynamic: true }),
         allowedMentions: {
@@ -92,13 +92,13 @@ module.exports = async (message, gdb) => {
     }
   } catch(e) { /* something went wrong */ }
   else if (modules.includes("reposting")) try {
-    countingMessage = await message.channel.send(`${message.author}: ${message.content}`);
+    countingMessage = await message.channel.send(`${message.author}: ${content}`);
     deleteMessage(message);
   } catch(e) { /* something went wrong */ }
   else if (modules.includes("embed")) try {
     countingMessage = await message.channel.send({
       embed: {
-        description: `${message.author}: ${message.content}`,
+        description: `${message.author}: ${content}`,
         color: message.member.displayColor || 3553598
       }
     });

--- a/src/handlers/counting.js
+++ b/src/handlers/counting.js
@@ -82,13 +82,12 @@ module.exports = async (message, gdb) => {
       countingMessage = await webhook.send(message.content, {
         username: message.author.username,
         avatarURL: message.author.displayAvatarURL({ dynamic: true }),
-      }), {
-      allowedMentions: {
-        users: [],
-        roles: [],
-        parse: [],
-      }
-    });
+        allowed_mentions: {
+          users: [],
+          roles: [],
+          parse: [],
+        }
+      });
       deleteMessage(message);
     }
   } catch(e) { /* something went wrong */ }

--- a/src/handlers/counting.js
+++ b/src/handlers/counting.js
@@ -82,7 +82,13 @@ module.exports = async (message, gdb) => {
       countingMessage = await webhook.send(message.content, {
         username: message.author.username,
         avatarURL: message.author.displayAvatarURL({ dynamic: true }),
-      });
+      }), {
+      allowedMentions: {
+        users: [],
+        roles: [],
+        parse: [],
+      }
+    });
       deleteMessage(message);
     }
   } catch(e) { /* something went wrong */ }


### PR DESCRIPTION
There is a bug with the Countr bot and the webhook count functionality that basically makes it so users can ping roles & users they otherwise wouldn't be able to ping. In order to get the bot to send the message, there is a very simple method. If you send the correct number and then quickly edit your message to whatever you want the bot to say, it will then send the edited message instead of the correct number. This can be abused to cause mass pings in servers. This is my simple fix to the ping problem until the message sending problem can be fixed.

Here is an example of how it can be abused (and yes, currently the webhook actually pings the role, which is what my pull request fixes):
![image](https://user-images.githubusercontent.com/49926644/130536095-1c880646-8b6d-48e9-939f-c8aa2ec60872.png)

Here is an example of a member abusing the bug by sending messages to ping the owner:
![image](https://user-images.githubusercontent.com/49926644/130536307-b470515c-0028-45cb-b087-640813e4a456.png)
