### PR TITLE
Introduce end-of-line normalization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=crlf


### PR DESCRIPTION
Add end-of-line normalisation, without it git automatically changes the eol to the system default
following https://git-scm.com/docs/gitattributes and https://eslint.org/docs/rules/linebreak-style