### PR TITLE
Remove .toString()

### DIFF
--- a/src/handlers/counting/repost/embed.ts
+++ b/src/handlers/counting/repost/embed.ts
@@ -5,7 +5,7 @@ export default async function repostWithEmbed(message: Message<true>): Promise<M
     return await message.channel.send({
       embeds: [
         {
-          description: `${message.author.toString()}: ${message.content}`,
+          description: `${message.author}: ${message.content}`,
           color: message.member?.displayColor ?? 3553598,
         },
       ],


### PR DESCRIPTION
> When concatenated with a string, this automatically returns the user's mention instead of the User object.

Signed-off-by: Talal <43641182+Ta1al@users.noreply.github.com>