### PR TITLE
Correct User Default Permission

### DIFF
--- a/src/commands/chatInput/index.ts
+++ b/src/commands/chatInput/index.ts
@@ -51,5 +51,5 @@ export const slashCommandPermissions: Record<string, PermissionLevel> = {
   modules: PermissionLevel.Admin,
   ping: PermissionLevel.None,
   select: PermissionLevel.None,
-  user: PermissionLevel.Admin,
+  user: PermissionLevel.None,
 };


### PR DESCRIPTION
Change the default permission level for the user command from Admin (Administrator) to None (Accessible to all users).