### PR TITLE
fix: tell the user there's no counting channels configured when using `/select` with no counting channels set up, and also in other commands requiring a counting channel

### DIFF
--- a/src/commands/chatInput/select.ts
+++ b/src/commands/chatInput/select.ts
@@ -1,5 +1,6 @@
 import { ApplicationCommandOptionType } from "discord.js";
 import countingChannels from "../../constants/autocompletes/countingChannels";
+import { docsUrl } from "../../constants/links";
 import selectedCountingChannels from "../../constants/selectedCountingChannel";
 import type { ChatInputCommand } from ".";
 
@@ -17,6 +18,7 @@ const command: ChatInputCommand = {
   autocompletes: { channel: countingChannels },
   execute(interaction, _, document) {
     const channel = interaction.options.getString("channel", true);
+    if (channel === "no-channel-configured") return void interaction.reply({ content: `💥 No counting channel is set up in this server! Create a new one by using \`/channels new\` or link an existing one with \`/channels link\`. New to Countr? Check out the [documentation](<${docsUrl}>) to get started!`, ephemeral: true });
     if (!document.channels.has(channel)) return void interaction.reply({ content: "❌ This channel isn't a configured counting channel.", ephemeral: true });
 
     selectedCountingChannels.set(interaction.user.id, channel);

--- a/src/constants/autocompletes/countingChannels.ts
+++ b/src/constants/autocompletes/countingChannels.ts
@@ -9,6 +9,13 @@ const autocomplete: Autocomplete = {
     const search = String(query);
 
     const countingChannels = Array.from(document.channels.entries());
+    if (!countingChannels.length) {
+      return [
+        { name: "No counting channels are configured in this server! Create one using the \"/channels new\" command.", value: "no-channel-configured" },
+        { name: "If you already have a counting channel, link it with the \"/channels link\" command.", value: "no-channel-configured" },
+      ];
+    }
+
     const countingChannelsFilteredAndSortedByRelevance = matchSorter(countingChannels.map(([id, countingChannel]) => {
       const channel = interaction.guild.channels.resolve(id) as CountingChannelAllowedChannelType | null;
       return {

--- a/src/handlers/interactions/chatInputCommands.ts
+++ b/src/handlers/interactions/chatInputCommands.ts
@@ -1,6 +1,7 @@
 import { inspect } from "util";
 import type { ChatInputCommandInteraction, Snowflake } from "discord.js";
 import type { ChatInputCommand } from "../../commands/chatInput";
+import { docsUrl } from "../../constants/links";
 import selectedCountingChannels from "../../constants/selectedCountingChannel";
 import type { CountingChannelSchema, GuildDocument } from "../../database/models/Guild";
 import { legacyImportDefault } from "../../utils/import";
@@ -33,6 +34,8 @@ export default async function chatInputCommandHandler(interaction: ChatInputComm
 
     const countingChannel = document.channels.get(interaction.channelId);
     if (command.disableInCountingChannel && countingChannel) return void interaction.reply({ content: "❌ This command is disabled in counting channels.", ephemeral: true });
+
+    if (command.requireSelectedCountingChannel && document.channels.size === 0) return void interaction.reply({ content: `💥 No counting channel is set up in this server! Create a new one by using \`/channels new\` or link an existing one with \`/channels link\`. New to Countr? Check out the [documentation](<${docsUrl}>) to get started!`, ephemeral: true });
 
     const selectedCountingChannelId = countingChannel ? interaction.channelId : selectedCountingChannels.get(interaction.user.id);
     const selectedCountingChannel: [Snowflake, CountingChannelSchema] | undefined = selectedCountingChannelId && document.channels.has(selectedCountingChannelId) ? [selectedCountingChannelId, document.channels.get(selectedCountingChannelId)!] : document.getDefaultCountingChannel() ?? undefined; // eslint-disable-line no-undefined

--- a/src/handlers/interactions/contextMenuCommands.ts
+++ b/src/handlers/interactions/contextMenuCommands.ts
@@ -1,36 +1,39 @@
+import { inspect } from "util";
 import type { ContextMenuCommandInteraction, Snowflake } from "discord.js";
 import { ApplicationCommandType } from "discord.js";
 import type { ContextMenuCommand } from "../../commands/menu";
-import config from "../../config";
+import { docsUrl } from "../../constants/links";
 import selectedCountingChannels from "../../constants/selectedCountingChannel";
 import type { CountingChannelSchema, GuildDocument } from "../../database/models/Guild";
 import { legacyImportDefault } from "../../utils/import";
+import commandsLogger from "../../utils/logger/commands";
 
 export default async function contextMenuCommandHandler(interaction: ContextMenuCommandInteraction<"cached">, document: GuildDocument): Promise<void> {
-  const commands = config.guild ? interaction.client.guilds.cache.get(config.guild)?.commands : interaction.client.application.commands;
-  const applicationCommand = commands?.cache.find(({ name }) => name === interaction.commandName);
-  if (!applicationCommand) return;
+  try {
+    const command = await legacyImportDefault<ContextMenuCommand>(require.resolve(`../../commands/menu/${interaction.commandName}`));
 
-  const command = await legacyImportDefault<ContextMenuCommand>(require.resolve(`../../commands/menu/${applicationCommand.name}`)).catch(() => null);
-  if (!command) return;
+    const countingChannel = document.channels.get(interaction.channelId);
+    if (command.disableInCountingChannel && countingChannel) return void interaction.reply({ content: "❌ This command is disabled in counting channels.", ephemeral: true });
 
-  const countingChannel = document.channels.get(interaction.channelId);
-  if (command.disableInCountingChannel && countingChannel) return void interaction.reply({ content: "❌ This command is disabled in counting channels.", ephemeral: true });
+    if (command.requireSelectedCountingChannel && document.channels.size === 0) return void interaction.reply({ content: `💥 No counting channel is set up in this server! Create a new one by using \`/channels new\` or link an existing one with \`/channels link\`. New to Countr? Check out the [documentation](<${docsUrl}>) to get started!`, ephemeral: true });
 
-  const selectedCountingChannelId = countingChannel ? interaction.channelId : selectedCountingChannels.get(interaction.user.id);
-  const selectedCountingChannel: [Snowflake, CountingChannelSchema] | undefined = selectedCountingChannelId && document.channels.has(selectedCountingChannelId) ? [selectedCountingChannelId, document.channels.get(selectedCountingChannelId)!] : document.getDefaultCountingChannel() ?? undefined; // eslint-disable-line no-undefined
+    const selectedCountingChannelId = countingChannel ? interaction.channelId : selectedCountingChannels.get(interaction.user.id);
+    const selectedCountingChannel: [Snowflake, CountingChannelSchema] | undefined = selectedCountingChannelId && document.channels.has(selectedCountingChannelId) ? [selectedCountingChannelId, document.channels.get(selectedCountingChannelId)!] : document.getDefaultCountingChannel() ?? undefined; // eslint-disable-line no-undefined
 
-  if (command.requireSelectedCountingChannel && !selectedCountingChannel) return void interaction.reply({ content: "💥 You need a counting channel selected to run this command. Type `/select` to select a counting channel and then run this command again.", ephemeral: true });
+    if (command.requireSelectedCountingChannel && !selectedCountingChannel) return void interaction.reply({ content: "💥 You need a counting channel selected to run this command. Type `/select` to select a counting channel and then run this command again.", ephemeral: true });
 
-  if (command.type === ApplicationCommandType.Message && interaction.isMessageContextMenuCommand()) {
-    const target = await interaction.channel?.messages.fetch(interaction.targetId).catch(() => null);
-    if (!target) return;
-    return command.execute(interaction, Boolean(countingChannel), target, document, (selectedCountingChannel ?? [null, null]) as never);
-  }
+    if (command.type === ApplicationCommandType.Message && interaction.isMessageContextMenuCommand()) {
+      const target = await interaction.channel?.messages.fetch(interaction.targetId).catch(() => null);
+      if (!target) return;
+      return await command.execute(interaction, Boolean(countingChannel), target, document, (selectedCountingChannel ?? [null, null]) as never);
+    }
 
-  if (command.type === ApplicationCommandType.User && interaction.isUserContextMenuCommand()) {
-    const target = await interaction.guild.members.fetch(interaction.targetId).catch(() => null);
-    if (!target) return;
-    return command.execute(interaction, Boolean(countingChannel), target, document, (selectedCountingChannel ?? [null, null]) as never);
+    if (command.type === ApplicationCommandType.User && interaction.isUserContextMenuCommand()) {
+      const target = await interaction.guild.members.fetch(interaction.targetId).catch(() => null);
+      if (!target) return;
+      return await command.execute(interaction, Boolean(countingChannel), target, document, (selectedCountingChannel ?? [null, null]) as never);
+    }
+  } catch (err) {
+    commandsLogger.debug(`Failed to run interaction command $${interaction.commandName} on interaction ${interaction.id}, channel ${interaction.channelId}, guild ${interaction.guildId}, member ${interaction.user.id}: ${inspect(err)}`);
   }
 }

--- a/src/handlers/mentionCommands.ts
+++ b/src/handlers/mentionCommands.ts
@@ -47,6 +47,8 @@ async function handleCommand(message: Message<true>, document: GuildDocument, ex
     command.debugLevel === DebugCommandLevel.Admin && !config.admins.includes(message.author.id)
   ) return reply("⛔ This command is not available.", message, existingReply).then(newReply => [message, newReply]);
 
+  if (command.requireSelectedCountingChannel && document.channels.size === 0) return reply("💥 No counting channel is set up in this server! Create a new one by using `/channels new` or link an existing one with `/channels link`.", message, existingReply).then(newReply => [message, newReply]);
+
   const selectedCountingChannelId = inCountingChannel ? message.channelId : selectedCountingChannels.get(message.author.id);
   const selectedCountingChannel: [Snowflake, CountingChannelSchema] | null = selectedCountingChannelId && document.channels.has(selectedCountingChannelId) ? [selectedCountingChannelId, document.channels.get(selectedCountingChannelId)!] : document.getDefaultCountingChannel();
 

--- a/src/handlers/mentionCommands.ts
+++ b/src/handlers/mentionCommands.ts
@@ -6,6 +6,7 @@ import { escapeInlineCode } from "discord.js";
 import type { MentionCommand } from "../commands/mention";
 import { quickResponses } from "../commands/mention";
 import config from "../config";
+import { docsUrl } from "../constants/links";
 import { DebugCommandLevel } from "../constants/permissions";
 import selectedCountingChannels from "../constants/selectedCountingChannel";
 import type { CountingChannelSchema, GuildDocument } from "../database/models/Guild";
@@ -47,7 +48,7 @@ async function handleCommand(message: Message<true>, document: GuildDocument, ex
     command.debugLevel === DebugCommandLevel.Admin && !config.admins.includes(message.author.id)
   ) return reply("⛔ This command is not available.", message, existingReply).then(newReply => [message, newReply]);
 
-  if (command.requireSelectedCountingChannel && document.channels.size === 0) return reply("💥 No counting channel is set up in this server! Create a new one by using `/channels new` or link an existing one with `/channels link`.", message, existingReply).then(newReply => [message, newReply]);
+  if (command.requireSelectedCountingChannel && document.channels.size === 0) return reply(`💥 No counting channel is set up in this server! Create a new one by using \`/channels new\` or link an existing one with \`/channels link\`. New to Countr? Check out the [documentation](<${docsUrl}>) to get started!`, message, existingReply).then(newReply => [message, newReply]);
 
   const selectedCountingChannelId = inCountingChannel ? message.channelId : selectedCountingChannels.get(message.author.id);
   const selectedCountingChannel: [Snowflake, CountingChannelSchema] | null = selectedCountingChannelId && document.channels.has(selectedCountingChannelId) ? [selectedCountingChannelId, document.channels.get(selectedCountingChannelId)!] : document.getDefaultCountingChannel();


### PR DESCRIPTION
Fixes #920 