### PR TITLE
feat: add a notice about Android clients not working with some commands (in this case, the `/select` command)

### DIFF
--- a/src/commands/chatInput/select.ts
+++ b/src/commands/chatInput/select.ts
@@ -17,7 +17,7 @@ const command: ChatInputCommand = {
   autocompletes: { channel: countingChannels },
   execute(interaction, _, document) {
     const channel = interaction.options.getString("channel", true);
-    if (!document.channels.has(channel)) return void interaction.reply({ content: "❌ This channel isn't a configured counting channel.", ephemeral: true });
+    if (!document.channels.has(channel)) return void interaction.reply({ content: "❌ Hmm, something went wrong here. Discord is currently having an issue with Android users not being able to use some commands. If you're on an Android device then please use the web browser or a computer to set up and interact with Countr. If you want to follow any progress on this issue then you can do so [in this GitHub issue](<https://github.com/countr/countr/issues/713>).", ephemeral: true });
 
     selectedCountingChannels.set(interaction.user.id, channel);
     return void interaction.reply({ content: `✅ You have selected <#${channel}> as your counting channel.`, ephemeral: true });


### PR DESCRIPTION
Notice (not a fix) to #713