### PR TITLE
fix: skip guild cache in dump command

### DIFF
--- a/src/commands/mention/dump.ts
+++ b/src/commands/mention/dump.ts
@@ -6,7 +6,7 @@ const command: MentionCommand = {
   debugLevel: DebugCommandLevel.Admin,
   testArgs(args) { return args.length === 0 || args.length === 1; },
   async execute(message, reply, [guildId = message.guildId]) {
-    const document = await getGuildDocument(guildId);
+    const document = await getGuildDocument(guildId, false);
     const data = JSON.stringify(document.toJSON(), null, 2);
     const now = Date.now();
 


### PR DESCRIPTION
fix cases where dumping a guild from a different cluster wouldn't work as expected