### PR TITLE
fix: variable name for math number system

### DIFF
--- a/src/constants/numberSystems/math.ts
+++ b/src/constants/numberSystems/math.ts
@@ -1,7 +1,7 @@
 import evaluate from "@emmetio/math-expression";
 import type { NumberSystem } from ".";
 
-const hexadecimal: NumberSystem = {
+const math: NumberSystem = {
   name: "Math Expressions (4*4 = 16)",
   convert: input => {
     const converted = evalMath(input);
@@ -11,7 +11,7 @@ const hexadecimal: NumberSystem = {
   format: number => number.toString(),
 };
 
-export default hexadecimal;
+export default math;
 
 function evalMath(input: string): null | number {
   try {


### PR DESCRIPTION
Fixed the variable name for the math number system from "hexadecimal" to just "math".